### PR TITLE
feat: add responsive mobile header with icons

### DIFF
--- a/shortcuts-disco-site/src/components/layout/header.tsx
+++ b/shortcuts-disco-site/src/components/layout/header.tsx
@@ -1,18 +1,27 @@
-import React from 'react';
+"use client";
+
 import Link from 'next/link';
-import { GithubIcon, TwitterIcon } from "@/components/ui/icons";
-import { MAIN_NAV_LINKS, SOCIAL_LINKS } from "@/lib/constants/navigation";
+import { usePathname } from 'next/navigation';
+import { GithubIcon, TwitterIcon, RaycastIcon } from "@/components/ui/icons";
+import { MAIN_NAV_LINKS, SOCIAL_LINKS, NavIconKey } from "@/lib/constants/navigation";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
-import { TypographyLarge } from "@/components/ui/typography";
+import { HelpCircle } from "lucide-react";
+
+const NAV_ICONS: Record<NavIconKey, React.ComponentType<{ className?: string }>> = {
+  HelpCircle,
+  Raycast: RaycastIcon,
+};
 
 /**
  * Header component for the application
  * Displays the logo, navigation links, and social media icons
  */
 export const Header = () => {
+  const pathname = usePathname();
+
   return (
     <header className="border-b">
-      <div className="mx-auto flex max-w-3xl items-center justify-between py-3">
+      <div className="mx-auto flex max-w-3xl items-center justify-between px-4 py-3">
         {/* Main navigation */}
         <nav className="flex items-center gap-4">
           {/* Logo */}
@@ -21,18 +30,24 @@ export const Header = () => {
           </Link>
           
           {/* Navigation links */}
-          {MAIN_NAV_LINKS.map((link, index) => (
-            <Link
-              key={link.href}
-              className={index === 0
-                ? "flex items-center gap-2 border-b-2 border-transparent hover:border-primary"
-                : "text-muted-foreground hover:text-foreground hover:border-b-2 hover:border-primary"
-              }
-              href={link.href}
-            >
-              {index === 0 ? <TypographyLarge>{link.label}</TypographyLarge> : link.label}
-            </Link>
-          ))}
+          {MAIN_NAV_LINKS.map((link) => {
+            const Icon = NAV_ICONS[link.icon];
+            const isActive = pathname === link.href;
+            return (
+              <Link
+                key={link.href}
+                className={isActive
+                  ? "text-foreground border-b-2 border-primary"
+                  : "text-muted-foreground hover:text-foreground hover:border-b-2 hover:border-primary"
+                }
+                href={link.href}
+              >
+                <Icon className="h-5 w-5 md:hidden" aria-hidden="true" />
+                <span className="hidden md:inline text-lg font-semibold">{link.label}</span>
+                <span className="sr-only md:hidden">{link.label}</span>
+              </Link>
+            );
+          })}
         </nav>
         
         {/* Social media links and theme toggle */}
@@ -42,11 +57,12 @@ export const Header = () => {
               key={link.href}
               className="text-foreground hover:underline"
               href={link.href}
+              aria-label={link.label}
             >
               {link.icon === "TwitterIcon" ? (
-                <TwitterIcon className="h-5 w-5" />
+                <TwitterIcon className="h-5 w-5" aria-hidden="true" />
               ) : (
-                <GithubIcon className="h-5 w-5" />
+                <GithubIcon className="h-5 w-5" aria-hidden="true" />
               )}
             </Link>
           ))}

--- a/shortcuts-disco-site/src/components/ui/icons.tsx
+++ b/shortcuts-disco-site/src/components/ui/icons.tsx
@@ -1,4 +1,8 @@
-export function GithubIcon(props: any) {
+import { SVGProps } from 'react';
+
+type IconProps = SVGProps<SVGSVGElement>;
+
+export function GithubIcon(props: IconProps) {
     return (
         <svg
             {...props}
@@ -18,7 +22,7 @@ export function GithubIcon(props: any) {
     )
 }
 
-export function MoonIcon(props: any) {
+export function MoonIcon(props: IconProps) {
     return (
         <svg
             {...props}
@@ -38,7 +42,7 @@ export function MoonIcon(props: any) {
 }
 
 
-export function MountainIcon(props: any) {
+export function MountainIcon(props: IconProps) {
     return (
         <svg
             {...props}
@@ -58,7 +62,7 @@ export function MountainIcon(props: any) {
 }
 
 
-export function TwitterIcon(props: any) {
+export function TwitterIcon(props: IconProps) {
     return (
         <svg
             {...props}
@@ -73,6 +77,26 @@ export function TwitterIcon(props: any) {
             strokeLinejoin="round"
         >
             <path d="M22 4s-.7 2.1-2 3.4c1.6 10-9.4 17.3-18 11.6 2.2.1 4.4-.6 6-2C3 15.5.5 9.6 3 5c2.2 2.6 5.6 4.1 9 4-.9-4.2 4-6.6 7-3.8 1.1 0 3-1.2 3-1.2z" />
+        </svg>
+    )
+}
+
+export function RaycastIcon(props: IconProps) {
+    return (
+        <svg
+            {...props}
+            width="24"
+            height="24"
+            viewBox="0 0 28 28"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M7 18.079V21L0 14L1.46 12.54L7 18.081V18.079ZM9.921 21H7L14 28L15.46 26.54L9.921 21ZM26.535 15.462L27.996 14L13.996 0L12.538 1.466L18.077 7.004H14.73L10.864 3.146L9.404 4.606L11.809 7.01H10.129V17.876H20.994V16.196L23.399 18.6L24.859 17.14L20.994 13.274V9.927L26.535 15.462ZM7.73 6.276L6.265 7.738L7.833 9.304L9.294 7.844L7.73 6.276ZM20.162 18.708L18.702 20.17L20.268 21.738L21.73 20.276L20.162 18.708ZM4.596 9.41L3.134 10.872L7 14.738V11.815L4.596 9.41ZM16.192 21.006H13.268L17.134 24.872L18.596 23.41L16.192 21.006Z"
+                fill="currentColor"
+            />
         </svg>
     )
 }

--- a/shortcuts-disco-site/src/lib/constants/navigation.ts
+++ b/shortcuts-disco-site/src/lib/constants/navigation.ts
@@ -2,26 +2,27 @@
  * Navigation constants for the application
  */
 
-// Main navigation links
+export type NavIconKey = "HelpCircle" | "Raycast";
+
+// Main navigation links (Home excluded since logo links to /)
 export const MAIN_NAV_LINKS = [
-  { href: "/", label: "Home" },
-  { href: "/about", label: "About" },
-  { href: "/raycast-extension", label: "Raycast Extension" },
-];
+  { href: "/about", label: "About", icon: "HelpCircle" },
+  { href: "/raycast-extension", label: "Raycast Extension", icon: "Raycast" },
+] as const satisfies readonly { href: string; label: string; icon: NavIconKey }[];
 
 // Social media links
 export const SOCIAL_LINKS = [
-  { 
-    href: "https://twitter.com/solomkinmv", 
+  {
+    href: "https://twitter.com/solomkinmv",
     label: "Twitter",
-    icon: "TwitterIcon" 
+    icon: "TwitterIcon"
   },
-  { 
-    href: "https://github.com/solomkinmv/shortcuts-disco", 
+  {
+    href: "https://github.com/solomkinmv/shortcuts-disco",
     label: "GitHub",
-    icon: "GithubIcon" 
+    icon: "GithubIcon"
   },
-];
+] as const;
 
 // Footer links
 export const FOOTER_LINKS = [


### PR DESCRIPTION
## Summary
- Show icons on mobile and text labels on desktop for navigation links
- Add custom RaycastIcon component for the Raycast Extension link
- Add horizontal padding for better mobile layout

## Test plan
- [x] View header on mobile viewport - should show icons only
- [x] View header on desktop viewport - should show text labels
- [x] Verify all navigation links work correctly